### PR TITLE
add `—release` in "Build From Source" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ To load static files such as `images`, `css`, and `javascript`, just use `{{load
 
     $ git clone https://github.com/mufeedvh/binserve.git
     $ cd binserve/
-    $ cargo build
+    $ cargo build --release
 
 ## Security
 


### PR DESCRIPTION
I think this is important for people without a Rust background. 