### PR TITLE
Fix template generation functions

### DIFF
--- a/src/error_pages.rs
+++ b/src/error_pages.rs
@@ -9,19 +9,19 @@ use std::path::Path;
 
 // create a default `404 Not Found` error page if it doesn't exist
 fn generate_404_page(static_dir: &str) -> std::io::Result<()> {
-    let contents = b"<html>\
-    <title>404 Not Found</title>\
-    <body>\
-    <h1>404 Not Found</h1>\
-    <hr>\
-    <p><i>binserve v0.1.0</i></p>\
-    </body>\
-    </html>";
+    const contents: &str = "<html>
+    <title>404 Not Found</title>
+    <body>
+        <h1>404 Not Found</h1>
+        <hr>
+        <p><i>binserve v0.1.0</i></p>
+    </body>
+</html>";
 
     let file_path = format!("{}/404.html", static_dir);
     if !Path::new(&file_path).exists() {
         let mut file = File::create(file_path)?;
-        file.write_all(contents)?;
+        file.write_all(contents.as_bytes())?;
     }
     Ok(())
 }

--- a/src/setup_static.rs
+++ b/src/setup_static.rs
@@ -13,15 +13,15 @@ pub fn setup_static() -> std::io::Result<()> {
     let config = get_config();
 
     // default `index.html` template
-    let index_contents = b"<html>\
-    <title>{{name}}</title>\
-    <body>\
-    <h1>Hello, universe!</h1>\
-    <h2>{{name}} is up and running!</h2>\
-    <hr>\
-    <p><i>binserve v0.1.0</i></p>\
-    </body>\
-    </html>";
+    const index_contents: &str = "<html>
+    <title>{{name}}</title>
+    <body>
+        <h1>Hello, universe!</h1>
+        <h2>{{name}} is up and running!</h2>
+        <hr>
+        <p><i>binserve v0.1.0</i></p>
+    </body>
+</html>";
 
     // create binserve static directories and files
     let static_dir = config["static_directory"].to_string().replace("\"", "");
@@ -34,7 +34,7 @@ pub fn setup_static() -> std::io::Result<()> {
         // create `index.html` homepage inside static directory
         if !Path::new(&index_html_path).exists() {
             let mut index_html = fs::File::create(index_html_path)?;
-            index_html.write_all(index_contents)?;
+        index_html.write_all(index_contents.as_bytes())?;
         }
     }
 

--- a/src/setup_static.rs
+++ b/src/setup_static.rs
@@ -34,7 +34,7 @@ pub fn setup_static() -> std::io::Result<()> {
         // create `index.html` homepage inside static directory
         if !Path::new(&index_html_path).exists() {
             let mut index_html = fs::File::create(index_html_path)?;
-        index_html.write_all(index_contents.as_bytes())?;
+            index_html.write_all(index_contents.as_bytes())?;
         }
     }
 


### PR DESCRIPTION
* Make all the templates a `const`
* Remove unrequired backslashes making them spread multiple lines
* Use as_bytes method to convert to bytes while writing rather than when initializing them