### PR TITLE
docker: add a minimalistic Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM rust:slim AS build
+ENV DEBIAN_FRONTEND=noninteractive
+WORKDIR /usr/src/binserve
+COPY . .
+
+RUN apt-get update && apt-get install -yf make pkg-config
+RUN cargo build --release && \
+    install -Dsvm755 ./target/release/binserve ./bin/binserve
+
+FROM gcr.io/distroless/cc:latest AS final
+WORKDIR /app
+COPY --from=build /usr/src/binserve/bin /app
+
+ENTRYPOINT [ "/app/binserve" ]


### PR DESCRIPTION
This pull request adds a minimalistic `Dockerfile` that contains only the `binserve` binary, a copy of `glibc` and other essential data files. This limits the attack surface to a minimum (the attacker can only compromise `binserve` at best and nothing more).

Note that if you use this image, you won't be able to use `docker exec` to examine the running container (since no shell program is provided).

This may fix #39.